### PR TITLE
Add critic review counts

### DIFF
--- a/README
+++ b/README
@@ -24,6 +24,9 @@ Use multiple concurrent requests (asyncio + aiohttp):
 python main.py --concurrency 5
 ```
 
+The generated CSV now includes a `critic_reviews` column with the number of
+professional critic reviews scraped from each game's page.
+
 Importance:
 Nintendo: Promoted Breath of the Wild as having “more perfect scores than any game in Metacritic history.”
 Sony: Aims for 90+ Metacritic scores on major titles, as noted by ex-art director Rafael Grassetti.


### PR DESCRIPTION
## Summary
- extend `Game` with `url` and `critic_reviews`
- fetch each game page to parse the number of critic reviews
- write the new `critic_reviews` column to the CSV
- update README with explanation of the new column

## Testing
- `python -m py_compile main.py meta.py`
- `python main.py --start 1 --end 1 --delay 0.1 --concurrency 1 --output test.csv`

------
https://chatgpt.com/codex/tasks/task_e_683fb5c96a4483219ce859daf6682ee6